### PR TITLE
Use package reference instead of project reference

### DIFF
--- a/ChiseledSqlClient/ChiseledSqlClient.csproj
+++ b/ChiseledSqlClient/ChiseledSqlClient.csproj
@@ -16,13 +16,13 @@
 
   <Target Name="RemoveAzureActiveDirectory" AfterTargets="ResolvePackageAssets" Condition="$(ChiselingEnabled) == 'true'">
     <ItemGroup>
-      <RuntimeCopyLocalItems Remove="@(RuntimeCopyLocalItems)" Condition="$([System.String]::Copy('%(RuntimeCopyLocalItems.NuGetPackageId)').StartsWith('Azure')) Or $([System.String]::Copy('%(RuntimeCopyLocalItems.NuGetPackageId)').StartsWith('Microsoft.Identity'))" />
+      <RuntimeCopyLocalItems Remove="@(RuntimeCopyLocalItems)" Condition="$([System.String]::Copy('%(RuntimeCopyLocalItems.NuGetPackageId)').StartsWith('Azure')) Or ($([System.String]::Copy('%(RuntimeCopyLocalItems.NuGetPackageId)').StartsWith('Microsoft.Identity')) And !$([System.String]::Copy('%(RuntimeCopyLocalItems.NuGetPackageId)').Equals('Microsoft.Identity.Client')))" />
       <NativeCopyLocalItems Remove="@(NativeCopyLocalItems)" Condition="$([System.String]::Copy('%(NativeCopyLocalItems.NuGetPackageId)').StartsWith('Microsoft.Identity'))" />
     </ItemGroup>
   </Target>
 
   <ItemGroup Condition="$(ChiselingEnabled) == 'true'">
-    <ProjectReference Include="..\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />
+    <PackageReference Include="Chiseled.Microsoft.Identity.Client" Version="100.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <PackageId>Chiseled.Microsoft.Identity.Client</PackageId>
     <DebugType>None</DebugType>
-    <!-- Must be same version as https://www.nuget.org/packages/Microsoft.Data.SqlClient/5.2.0#dependencies-body-tab -->
-    <Version>4.56.0</Version>
+    <!-- Must be above version at https://www.nuget.org/packages/Microsoft.Data.SqlClient/5.2.0#dependencies-body-tab -->
+    <Version>100.0.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="cmic" value="https://www.myget.org/F/chiseled-microsoft-identity-client/api/v3/index.json" />
+  </packageSources>
+
+  <packageSourceMapping>
+    <!-- key value for <packageSource> should match key values from <packageSources> element -->
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="cmic">
+      <package pattern="Chiseled.Microsoft.Identity.Client" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
This requires less effort for the user since they can simply reference a nuget package.

If you like the approach we can remove the `nuget.config` file and use nuget instead of myget.